### PR TITLE
Multiple New Features, Updates, & Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![GitHub](https://img.shields.io/github/license/CarverCounty/SPSiteContentsList?style=for-the-badge)
 ![GitHub file size in bytes](https://img.shields.io/github/size/CarverCounty/SPSiteContentsList/SiteContents.html?style=for-the-badge)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/CarverCounty/SPSiteContentsList?style=for-the-badge)
+![GitHub Release Date](https://img.shields.io/github/release-date/CarverCounty/SPSiteContentsList?style=for-the-badge)
 
 This is a simple solution for screen scraping the lists, libaries, and subsites from a SharePoint 2013<sup>[1](#1)</sup> Site Contents page.<br>This comes in handy for extracting a list of a site's contents and metadata for cleanup purposes.<br>It can be used by any user with access to upload files.<sup>[2](#2)</sup>
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![GitHub](https://img.shields.io/github/license/CarverCounty/SPSiteContentsList?style=for-the-badge)
 ![GitHub file size in bytes](https://img.shields.io/github/size/CarverCounty/SPSiteContentsList/SiteContents.html?style=for-the-badge)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/CarverCounty/SPSiteContentsList?style=for-the-badge)
 ![GitHub Release Date](https://img.shields.io/github/release-date/CarverCounty/SPSiteContentsList?style=for-the-badge)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/CarverCounty/SPSiteContentsList?style=for-the-badge)
 
 This is a simple solution for screen scraping the lists, libaries, and subsites from a SharePoint 2013<sup>[1](#1)</sup> Site Contents page.<br>This comes in handy for extracting a list of a site's contents and metadata for cleanup purposes.<br>It can be used by any user with access to upload files.<sup>[2](#2)</sup>
 
@@ -12,7 +12,7 @@ This is a simple solution for screen scraping the lists, libaries, and subsites 
 
 This four step process is the simplest deployment, but it will not include your branding or navigation.<br>If that's something you'd like, please use the [Alternate Deployment](#alternate-deployment) instructions below.
 
-1. Download the [SiteContents.html](https://raw.githubusercontent.com/CarverCounty/SPSiteContentsList/master/SiteContents.html) file.<sup>[3](#3)</sup>
+1. Download the [SiteContents.html](https://github.com/CarverCounty/SPSiteContentsList/releases/latest) file.<sup>[3](#3)</sup>
 
 2. Upload the file to a library, like SiteAssets, within your SharePoint Farm.
 
@@ -23,7 +23,7 @@ This four step process is the simplest deployment, but it will not include your 
 
 ### Alternate Deployment
 
-1. Download the [SiteContents.html](https://raw.githubusercontent.com/CarverCounty/SPSiteContentsList/master/SiteContents.html) file.<sup>[3](#3)</sup>
+1. Download the [SiteContents.html](https://github.com/CarverCounty/SPSiteContentsList/releases/latest) file.<sup>[3](#3)</sup>
 
 2. Upload the file to a library, like SiteAssets, at the __root of the site collection__.<sup>[5](#5)</sup>
 
@@ -55,7 +55,7 @@ _<sup><a name='1'>1</a></sup>This has only been tested on SharePoint 2013 using 
 
 _<sup><a name='2'>2</a></sup>The results are permission trimmed, meaning you will only see what you have access to see in the results._
 
-_<sup><a name='3'>3</a></sup>To 'download' the script, you'll need to copy the script text and paste it into a new text file saved as a `.html` extension._
+_<sup><a name='3'>3</a></sup>To download the script, click the SiteContents.html link on the [latest release](https://github.com/CarverCounty/SPSiteContentsList/releases/latest)._
 
 _<sup><a name='4'>4</a></sup>For the Submit button to work on the current site, the script or page must be saved to the root of a document library. It cannot be placed in a folder._
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![GitHub file size in bytes](https://img.shields.io/github/size/CarverCounty/SPSiteContentsList/SiteContents.html?style=for-the-badge)
 ![GitHub Release Date](https://img.shields.io/github/release-date/CarverCounty/SPSiteContentsList?style=for-the-badge)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/CarverCounty/SPSiteContentsList?style=for-the-badge)
+![GitHub All Releases](https://img.shields.io/github/downloads/CarverCounty/SPSiteContentsList/total?style=for-the-badge)
 
 This is a simple solution for screen scraping the lists, libaries, and subsites from a SharePoint 2013<sup>[1](#1)</sup> Site Contents page.<br>This comes in handy for extracting a list of a site's contents and metadata for cleanup purposes.<br>It can be used by any user with access to upload files.<sup>[2](#2)</sup>
 
@@ -67,8 +68,3 @@ _<sup><a name='6'>6</a></sup>This script will not work on a page that uses ```_l
 ## License
 
 This project uses the following license: [Unlicense](LICENSE).
-
-
-## Disclaimer
-
-We provide no guarantee of any kind this script will be kept up to date, nor do we guarantee support of any kind to make it work in any environment other than our own.

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -10,6 +10,7 @@
 <label for='sitePath'>Site Path</label><br>
 <input type='text' id='sitePath' style='width:500px;' placeholder='Leave blank for current site'><br><br>
 <button 
+	id='Submit' 
 	onclick='querySite($(sitePath).val()); return false;' 
 	style='margin: 0 20px 10px 0!important;'>Submit
 </button>
@@ -52,6 +53,19 @@
 				$('#checkVersion').html('<p><strong style="color:red;">BETA VERSION (' + thisVersion + ')</strong> - This version is not a <a href="https://github.com' + releasePath + '" target="_blank">supported release</a>.</p>');
 			}
 		});
+		
+		/* When a key is pressed on the keyboard while the cursor is in the sitePath textbox... */
+		$('input#sitePath').keypress(function(e){
+
+			/* If the key pressed is the Enter key */
+			if(e.keyCode == 13){
+
+				/* Prevent the page from reloading */
+				e.preventDefault();
+
+				/* Click the Submit button */
+				$('#Submit').click();
+			}
 		});
 	});
 

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -7,16 +7,23 @@
 -->
 <!-- Upgrade div container, textbox label, site path textbox, submit button, and Copy to Clipboard button -->
 <div id='checkVersion'></div>
-<label for='sitePath'>Site Path </label>
+<label for='sitePath'>Site Path</label><br>
 <input type='text' id='sitePath' style='width:500px;' placeholder='Leave blank for current site'><br><br>
-<button onclick='querySite($(sitePath).val()); return false;' style='margin-left:0px!important;'>Submit</button>
-<button onclick='copyToClipboard(document.getElementById("siteContentsResults")); return false;' style='margin-left:0px!important;'>Copy to Clipboard</button><br><hr>
+<button 
+	onclick='querySite($(sitePath).val()); return false;' 
+	style='margin: 0 20px 10px 0!important;'>Submit
+</button>
+<button 
+	onclick='copyToClipboard(document.getElementById("siteContentsResults")); return false;' 
+	style='margin: 0 20px 10px 0!important;'>Copy to Clipboard
+</button><br>
+<hr>
 
 <!-- HTML object where the Site Contents will be displayed -->
 <div id='siteContentsResults'></div>
 
 <!-- Import jQuery -->
-<script src='//code.jquery.com/jquery-3.3.1.min.js'></script>
+<script src='//code.jquery.com/jquery-3.4.1.min.js'></script>
 
 <!-- JavaScript -->
 <script>
@@ -49,8 +56,6 @@
 			return;
 		}
 
-		/* Clear page content */
-		$('#siteContentsResults').html('');
 
 		/* If text in textbox exists, append Site Contents path */
 		if(site){path = site + '/_layouts/15/viewlsts.aspx';}
@@ -64,7 +69,7 @@
 		}
 		
 		/* Create Site title and link to Site Contents */
-		$('#siteContentsResults').append('<strong>SITE:</strong> <a href="' + path + '" target="_blank" title="Site Contents">' + site + '</a><br><br>');
+		$('#siteContentsResults').html('<strong>SITE:</strong> <a href="' + path + '" target="_blank" title="Site Contents">' + site + '</a><br><br>');
 
 		/* Declare string variable to hold list of results */
 		var results = '';

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -5,7 +5,8 @@
 	Link: https://github.com/CarverCounty/SPSiteContentsList
 	Auth: Carver County
 -->
-<!-- Label, text field, submit button, and Copy to Clipboard button -->
+<!-- Upgrade div container, textbox label, site path textbox, submit button, and Copy to Clipboard button -->
+<div id='checkVersion'></div>
 <label for='sitePath'>Site Path </label>
 <input type='text' id='sitePath' style='width:500px;' placeholder='Leave blank for current site'><br><br>
 <button onclick='querySite($(sitePath).val()); return false;' style='margin-left:0px!important;'>Submit</button>
@@ -19,6 +20,24 @@
 
 <!-- JavaScript -->
 <script>
+
+	/* When page has been successfully loaded... */
+	$(document).ready(function(){
+
+		/* Variable to hold the current version number */
+		var thisVersion = 'v1.0.1';
+
+		/* Query the latest releases page on GitHub */
+		$.get('https://api.github.com/repos/CarverCounty/SPSiteContentsList/releases/latest', function(data){
+			
+			/* Store latest release version number in variable */
+			var latestRelease = data.tag_name;
+			
+			/* If current version not equal to latest release version, display New Version message on page */
+			if(latestRelease != thisVersion) $('#checkVersion').html('<a href="https://github.com/CarverCounty/SPSiteContentsList/releases/latest" target="_blank">New Version Available</a><br>');
+		});
+	});
+
 	/* Function to be called when Submit button is clicked */
 	function querySite(site){
 
@@ -44,7 +63,7 @@
 			site = 'CURRENT';
 		}
 		
-		/* Create Site itle and link to Site Contents */
+		/* Create Site title and link to Site Contents */
 		$('#siteContentsResults').append('<strong>SITE:</strong> <a href="' + path + '" target="_blank" title="Site Contents">' + site + '</a><br><br>');
 
 		/* Declare string variable to hold list of results */

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -18,6 +18,12 @@
 	onclick='copyToClipboard(document.getElementById("siteContentsResults")); return false;' 
 	style='margin: 0 20px 10px 0!important;'>Copy to Clipboard
 </button><br>
+<span id='resizeText' style='display:none;' title='Resize the results text'>
+	Text Size:&nbsp;&nbsp;&nbsp;
+	<span id='small' style='font-size:small;cursor:pointer;'>T</span>&nbsp;&nbsp;|&nbsp;&nbsp;
+	<span id='medium' style='font-size:large;cursor:pointer;'>T</span>&nbsp;&nbsp;|&nbsp;&nbsp;
+	<span id='large' style='font-size:x-large;cursor:pointer;'>T</span>
+</span>
 <hr>
 
 <!-- HTML object where the Site Contents will be displayed -->
@@ -67,10 +73,19 @@
 				$('#Submit').click();
 			}
 		});
+
+		/* Resize the results list text based on text size selection */
+		$('#small').click(function(){$('#siteContentsResults, #siteContentsResults li span').css({'font-size':'small'});});
+		$('#medium').click(function(){$('#siteContentsResults, #siteContentsResults li span').css({'font-size':'large'});});
+		$('#large').click(function(){$('#siteContentsResults, #siteContentsResults li span').css({'font-size':'x-large'});});
+		
 	});
 
 	/* Function to be called when Submit button is clicked */
 	function querySite(site){
+
+		/* Show Resize Text section */
+		$('#resizeText').css({'display':'inline'});
 
 		/* If text in textbox contains full path to homepage in Site Pages... */
 		if(site && site.substr(site.length - 20).toLowerCase() == '/sitepages/home.aspx') {
@@ -135,7 +150,7 @@
 				var objName = '<a href=\'' + linkData.prop('href') + '\' target=\'_blank\'>' + linkData.text().trim() + '</a> - ';
 
 				/* Create and format the list item */
-				results += '<li>' + objName + metaData[0].innerHTML.trim() + ' - ' + metaData[1].innerHTML.trim().replace('Modified','') + '</li>';
+				results += '<li><span>' + objName + metaData[0].innerHTML.trim() + ' - ' + metaData[1].innerHTML.trim().replace('Modified','') + '</span></li>';
 			});
 
 			/* If results exist, write Lists & Libraries title and results to page */
@@ -148,7 +163,7 @@
 			$('.ms-itmhover .ms-vb-icon a:not(.ms-vl-siteicon)',siteContentsHTML).each(function(){
 
 				/* Build and format the list item */
-				results += '<li><a href=\'' + $(this).prop('href') + '\' target=\'_blank\'>' + $(this).text().trim() + '</a></li>';
+				results += '<li><span><a href=\'' + $(this).prop('href') + '\' target=\'_blank\'>' + $(this).text().trim() + '</a></span></li>';
 			});
 
 			/* If results exist, write Sites title and results to page */

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -72,17 +72,32 @@
 	/* Function to be called when Submit button is clicked */
 	function querySite(site){
 
-		/* If text in textbox exists and last four characters equal 'aspx' */
-		if(site && site.substr(site.length - 4) == 'aspx'){
+		/* If text in textbox contains full path to homepage in Site Pages... */
+		if(site && site.substr(site.length - 20).toLowerCase() == '/sitepages/home.aspx') {
 		
-			/* Write message to page and exit function */
+			/* Replace homepage path with Site Contents path */
+			path = site.replace(site.substr(site.length - 20),'') + '/_layouts/15/viewlsts.aspx';
+
+		/* Else If text in textbox contains full path to homepage in Pages... */
+		} else if(site && site.substr(site.length - 16).toLowerCase() == '/pages/home.aspx') {
+		
+			/* Replace homepage path with Site Contents path */
+			path = site.replace(site.substr(site.length - 16),'') + '/_layouts/15/viewlsts.aspx';
+		
+		/* Else If text in textbox exists and last four characters equal 'aspx'... */
+		} else if(site && site.substr(site.length - 4).toLowerCase() == 'aspx'){
+		
+			/* Write error message to page */
 			$('#siteContentsResults').html('The site path is invalid.<br>Please ensure the path ends with the site name.');
+
+			/* Exit function */
 			return;
-		}
-
-
-		/* If text in textbox exists, append Site Contents path */
-		if(site){path = site + '/_layouts/15/viewlsts.aspx';}
+			
+		/* Else If text in textbox exists... */
+		} else if(site){
+			
+			/* Append Site Contents path to site */
+			path = site + '/_layouts/15/viewlsts.aspx';}
 
 		/* Else, if textbox is blank... */
 		else{

--- a/SiteContents.html
+++ b/SiteContents.html
@@ -34,14 +34,24 @@
 		/* Variable to hold the current version number */
 		var thisVersion = 'v1.0.1';
 
-		/* Query the latest releases page on GitHub */
-		$.get('https://api.github.com/repos/CarverCounty/SPSiteContentsList/releases/latest', function(data){
+		/* Path to GitHub Latest Release */
+		var releasePath = '/CarverCounty/SPSiteContentsList/releases/latest';
+
+		/* Query the latest releases on GitHub */
+		$.get('https://api.github.com/repos' + releasePath, function(data){
 			
 			/* Store latest release version number in variable */
 			var latestRelease = data.tag_name;
 			
-			/* If current version not equal to latest release version, display New Version message on page */
-			if(latestRelease != thisVersion) $('#checkVersion').html('<a href="https://github.com/CarverCounty/SPSiteContentsList/releases/latest" target="_blank">New Version Available</a><br>');
+			/* If current version less than latest release version, display New Version message on page */
+			if(latestRelease > thisVersion) {
+				$('#checkVersion').html('<p style="font-weight:bold;"><a href="https://github.com' + releasePath + '" target="_blank">New Version Available (' + latestRelease + ')</a></p>');
+
+			/* Else If current version greater than latest release version, display Beta Version message on page */
+			} else if(latestRelease < thisVersion) {
+				$('#checkVersion').html('<p><strong style="color:red;">BETA VERSION (' + thisVersion + ')</strong> - This version is not a <a href="https://github.com' + releasePath + '" target="_blank">supported release</a>.</p>');
+			}
+		});
 		});
 	});
 


### PR DESCRIPTION
### :sparkles: New Features
- Added version checking for latest release (#2) 
- Added [shields.io](https://shields.io/) metadata badges for release date, latest release version, and number of downloads on README
- Added feature where enter key presses Submit button (#4)
- Added ability to change size of text results to small, medium, or large (#5)
- Added check and adjustment for pasted URLs including `/sitepages/home.aspx` and `/pages/home.aspx` (#3)
  - Added error message when URL is another path that ends in `.aspx`

### :zap: Updates
- Updated instructions on README for downloading the SiteContents.html file from the latest release
- Fixed misspellings
- Updated minor HTML and CSS formatting
- Updated jQuery version from 3.3.1 -> 3.4.1
- Cleaned up some unnecessary code
- Removed Disclaimer from README (duplicated in [LICENSE](/CarverCounty/SPSiteContentsList/blob/master/LICENSE#L16-L22))

### :beetle: Bug Fixes
- Fixed bug where enter key would open SharePoint page in Edit Mode (#4)
- Fixed bug where some copied text would not keep increased size formatting

